### PR TITLE
Make `Result` a wrapper, not a re-implementation.

### DIFF
--- a/examples/pattern_matching.rs
+++ b/examples/pattern_matching.rs
@@ -1,7 +1,5 @@
 #![feature(try_blocks)]
 
-use propagate::CodeLocationStack;
-
 #[derive(Debug)]
 enum MyError {
     Str(&'static str),
@@ -18,18 +16,18 @@ fn maybe_int() -> propagate::Result<u32, MyError> {
 }
 
 fn main() {
-    let result = maybe_int();
+    let (result, stack) = maybe_int().unpack();
     match result {
-        propagate::Ok(i) => println!("Got int: {}", i),
-        propagate::Err(e) => {
-            let error: &MyError = e.error();
-            match error {
+        Ok(i) => {
+            println!("Got int: {}", i);
+            assert!(matches!(stack, None));
+        }
+        Err(e) => {
+            match e {
                 MyError::Str(s) => println!("Error: {}", s),
                 MyError::Other => println!("Error (other)"),
             }
-
-            let stack: &CodeLocationStack = e.stack();
-            println!("\nStack: {}", stack);
+            println!("\nStack: {}", stack.unwrap());
         }
     }
 }

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -5,8 +5,6 @@ use std::error::Error;
 use std::fs::File;
 use std::io;
 
-use propagate::TracedError;
-
 #[derive(Debug)]
 enum MyError {
     Unlucky,
@@ -47,8 +45,6 @@ fn file_size(path: &str) -> propagate::Result<u64, MyError> {
         let size = File::open(path)?.metadata()?.len();
 
         if size < 1024 {
-            // Option 1: Coerce a `std::result::Result` to a `propagate::Result`
-            // using `?`.
             Err(MyError::TooSmall(size))?
         }
 
@@ -61,9 +57,7 @@ fn maybe_file_size(path: &str) -> propagate::Result<u64, MyError> {
 
     try {
         if !lucky {
-            // Option 2: Directly construct a `propagate::Result`
-            // using `TracedError::new()`.
-            propagate::Err(TracedError::new(MyError::Unlucky))?
+            Err(MyError::Unlucky)?
         }
 
         file_size(path)?

--- a/examples/usage_no_try.rs
+++ b/examples/usage_no_try.rs
@@ -3,8 +3,6 @@ use std::error::Error;
 use std::fs::File;
 use std::io;
 
-use propagate::TracedError;
-
 #[derive(Debug)]
 enum MyError {
     Unlucky,
@@ -48,7 +46,7 @@ fn file_size(path: &str) -> propagate::Result<u64, MyError> {
         // using `?`.
         Err(MyError::TooSmall(size))?
     } else {
-        propagate::Ok(size)
+        propagate::ok(size)
     }
 }
 
@@ -57,15 +55,15 @@ fn maybe_file_size(path: &str) -> propagate::Result<u64, MyError> {
 
     if !lucky {
         // Option 2: Directly construct a `propagate::Result`
-        // using `TracedError::new()`.
-        propagate::Err(TracedError::new(MyError::Unlucky))
+        // using `propagate::err()`.
+        propagate::err(MyError::Unlucky)
     } else {
-        propagate::Ok(file_size(path)?)
+        propagate::ok(file_size(path)?)
     }
 }
 
 fn main() -> propagate::Result<(), MyError> {
     let size = maybe_file_size("foo.txt")?;
     println!("File size: {} KiB", size / 1024);
-    propagate::Ok(())
+    propagate::ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Error propagation tracing in Rust.
 //!
-//! This crate provides [`propagate::Result`], a replacement for the standard
+//! This crate provides [`propagate::Result`], a wrapper around the standard
 //! library result type that automatically tracks the propagation of error
 //! results using the `?` operator.
 //!
@@ -74,16 +74,16 @@
 //! }
 //!
 //! # fn main() {
-//! #     let result = maybe_file_size("foo.txt");
+//! #     let (result, stack) = maybe_file_size("foo.txt").unpack();
 //! #     match result {
-//! #         propagate::Ok(size) => println!("File size: {} KiB", size / 1024),
-//! #         propagate::Err(err) => {
-//! #             match err.error() {
+//! #         Ok(size) => println!("File size: {} KiB", size / 1024),
+//! #         Err(err) => {
+//! #             match err {
 //! #                 MyError::Unlucky => println!("Not this time!"),
 //! #                 MyError::Io(e) => println!("I/O error: {}", e),
 //! #                 MyError::TooSmall(size) => println!("File too small: {} bytes", size),
 //! #             }
-//! #             println!("Backtrace: {}", err.stack());
+//! #             println!("Backtrace: {}", stack.unwrap());
 //! #         }
 //! #     }
 //! # }
@@ -113,11 +113,9 @@
 //!     let size = File::open(path)?.metadata()?.len();
 //!
 //!     if size < 1024 {
-//!         // Option 1: Coerce a `std::result::Result` to a`propagate::Result`
-//!         // using `?`.
-//!         Err(MyError::TooSmall(size))?
+//!         propagate::err(MyError::TooSmall(size))
 //!     } else {
-//!         propagate::Ok(size)
+//!         propagate::ok(size)
 //!     }
 //! }
 //!
@@ -125,12 +123,10 @@
 //!     let lucky = (path.len() % 2) == 0;
 //!
 //!     if !lucky {
-//!         // Option 2: Directly construct a `propagate::Result`
-//!         // using `Result::new_err()`.
-//!         propagate::Result::new_err(MyError::Unlucky)
+//!         propagate::err(MyError::Unlucky)
 //!     } else {
-//!         // Must remember to surround with `Ok(..?)`.
-//!         propagate::Ok(file_size(path)?)
+//!         // Must remember to surround with `ok(..?)`.
+//!         propagate::ok(file_size(path)?)
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,14 +152,7 @@ pub mod result;
 #[doc(inline)]
 pub use self::{
     error::{CodeLocation, CodeLocationStack, TracedError},
-    result::{Result, Traced},
+    result::{err, ok, Result, Traced},
 };
-
-pub use self::result::Result::{Err, Ok};
-
-pub mod prelude {
-    pub use crate::error::TracedError;
-    pub use crate::result::Result;
-}
 
 mod test;

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,12 +9,23 @@ use std::ops::{ControlFlow, FromResidual, Try};
 use std::panic::Location;
 use std::process::Termination;
 
-pub use self::Result::Err;
-pub use self::Result::Ok;
-
 /// A trait denoting "stack-like" types that can be used with [`Result<T, E, S>`].
 pub trait Traced {
     fn trace(&mut self, location: &'static Location);
+}
+
+/// Construct a new [`propagate::Result`][crate::Result] with the given success value.
+#[inline]
+pub fn ok<T, E, S>(ok_value: T) -> Result<T, E, S> {
+    self::Result(Ok(ok_value))
+}
+
+/// Construct a new [`propagate::Result`][crate::Result] with the given error value.
+#[inline]
+#[track_caller]
+pub fn err<T, E, S: Traced + Default, F: From<E>>(err_value: E) -> Result<T, F, S> {
+    let wrapped = TracedError::new(F::from(err_value));
+    self::Result(Err(wrapped))
 }
 
 /*  ____                 _ _    _______   _______
@@ -26,7 +37,9 @@ pub trait Traced {
  *  FIGLET: Result<T, E>
  */
 
-/// A replacement for [`std::result::Result<T, E>`] that supports chaining via the `?` operator.
+/// A wrapper around [`std::result::Result<T, E>`] that supports chaining via the `?` operator.
+///
+/// TODO: document custom stack types.
 ///
 /// # Propagation Using `?`
 ///
@@ -204,12 +217,7 @@ pub trait Traced {
 /// [`propagate::Result`]: crate::Result
 #[must_use = "this `Result` may be an `Err` variant, which should be handled"]
 #[derive(PartialEq, Eq, Debug, Hash)]
-pub enum Result<T, E, S = CodeLocationStack> {
-    /// Contains the success value.
-    Ok(T),
-    /// Contains the error value wrapped in a [`TracedError`].
-    Err(TracedError<E, S>),
-}
+pub struct Result<T, E, S = CodeLocationStack>(std::result::Result<T, TracedError<E, S>>);
 
 /*  _                 _   _____
  * (_)_ __ ___  _ __ | | |_   _| __ _   _
@@ -238,14 +246,14 @@ impl<T, E, S: Traced> Try for Result<T, E, S> {
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
-        Self::Ok(output)
+        Self(Ok(output))
     }
 
     #[inline]
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
-        match self {
+        match self.0 {
             Ok(ok) => ControlFlow::Continue(ok),
-            Err(err) => ControlFlow::Break(Err(err)),
+            Err(err) => ControlFlow::Break(Result(Err(err))),
         }
     }
 }
@@ -259,11 +267,11 @@ where
     #[inline]
     #[track_caller]
     fn from_residual(residual: Result<Infallible, E, S>) -> Self {
-        match residual {
+        match residual.0 {
             Ok(_) => unreachable!(),
             Err(mut e) => {
                 e.push_caller();
-                Err(e.convert_inner())
+                Self(Err(e.convert_inner()))
             }
         }
     }
@@ -279,8 +287,11 @@ where
     #[track_caller]
     fn from_residual(residual: std::result::Result<Infallible, E>) -> Self {
         match residual {
-            std::result::Result::Ok(_) => unreachable!(),
-            std::result::Result::Err(e) => Err(TracedError::new(From::from(e))),
+            Ok(_) => unreachable!(),
+            Err(e) => {
+                let wrapped = TracedError::new(F::from(e));
+                Self(Err(wrapped))
+            }
         }
     }
 }
@@ -297,7 +308,7 @@ where
 
 impl<T, E: std::error::Error, S: fmt::Display> Termination for Result<T, E, S> {
     fn report(self) -> i32 {
-        match self {
+        match self.0 {
             Ok(_) => 0,
             Err(err) => {
                 println!(
@@ -322,9 +333,9 @@ impl<T, E: std::error::Error, S: fmt::Display> Termination for Result<T, E, S> {
  *  FIGLET: impl Result
  */
 
-/// Stuff not from the standard library.
-impl<T, E, S: Traced + Default> Result<T, E, S> {
-    /// Constructs a new error result from the provided error value.
+impl<T, E, S> Result<T, E, S> {
+    /// Converts from `Result<T, E>` to [`std::result::Result<T, E>`]
+    /// and returns the traced stack if it is `Err`.
     ///
     /// # Examples
     ///
@@ -332,536 +343,21 @@ impl<T, E, S: Traced + Default> Result<T, E, S> {
     ///
     /// ```
     /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = Result::new_err("Nothing here");
+    /// let x: Result<(), &str> = propagate::err("Nothing here");
+    /// let (result, stack) = x.unpack();
+    /// assert!(matches!(result, Err("Nothing here")));
+    /// assert_eq!(stack.unwrap().0.len(), 1);
     /// ```
-    #[inline]
-    #[track_caller]
-    pub fn new_err<D>(error_value: D) -> Self
-    where
-        E: From<D>,
-    {
-        Err(TracedError::new(E::from(error_value)))
-    }
-}
-
-impl<T, E, S: Traced> Result<T, E, S> {
-    /// Converts from `Result<T, E>` to [`std::result::Result<T, E>`].
-    ///
-    /// Converts `self` into a [`std::result::Result<T, E>`], consuming `self`.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(2);
-    /// assert_eq!(x.to_std(), std::result::Result::Ok(2));
-    ///
-    /// let x: Result<u32, &str> = Result::new_err("Nothing here");
-    /// assert_eq!(x.to_std(), std::result::Result::Err("Nothing here"));
-    /// ```
-    #[inline]
-    pub fn to_std(self) -> std::result::Result<T, E> {
-        match self {
-            Ok(t) => std::result::Result::Ok(t),
-            Err(e) => std::result::Result::Err(e.error),
+    pub fn unpack(self) -> (std::result::Result<T, E>, Option<S>) {
+        match self.0 {
+            Ok(ok) => (Ok(ok), None),
+            Err(err) => {
+                let inner = err.error;
+                let stack = err.stack;
+                (Err(inner), Some(stack))
+            }
         }
     }
-
-    #[inline]
-    pub fn as_std_ref(&self) -> std::result::Result<&T, &E> {
-        match self {
-            Ok(ref t) => std::result::Result::Ok(t),
-            Err(ref e) => std::result::Result::Err(&e.error),
-        }
-    }
-
-    /// Converts from `Result<T, E>` to [`Option<TracedError<E>>`].
-    ///
-    /// Converts `self` into an [`Option<TracedError<E>>`], consuming `self`,
-    /// and discarding the success value, if any.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(2);
-    /// assert!(matches!(x.err_stack(), None));
-    ///
-    /// let x: Result<u32, &str> = Result::new_err("Nothing here");
-    /// match x.err_stack() {
-    ///     Some(e) => assert_eq!(*e.error(), "Nothing here"),
-    ///     None => unreachable!(),
-    /// }
-    /// ```
-    #[inline]
-    pub fn err_stack(self) -> Option<TracedError<E, S>> {
-        match self {
-            Ok(_) => None,
-            Err(x) => Some(x),
-        }
-    }
-}
-
-impl<T, E> Result<T, E> {
-    /////////////////////////////////////////////////////////////////////////
-    // Querying the contained values
-    /////////////////////////////////////////////////////////////////////////
-
-    /// Returns `true` if the result is [`Ok`].
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<i32, &str> = propagate::Ok(-3);
-    /// assert_eq!(x.is_ok(), true);
-    ///
-    /// let x: Result<i32, &str> = Result::new_err("Some error message");
-    /// assert_eq!(x.is_ok(), false);
-    /// ```
-    #[must_use = "if you intended to assert that this is ok, consider `.unwrap()` instead"]
-    #[inline]
-    pub const fn is_ok(&self) -> bool {
-        matches!(*self, Ok(_))
-    }
-
-    /// Returns `true` if the result is [`Err`].
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<i32, &str> = propagate::Ok(-3);
-    /// assert_eq!(x.is_err(), false);
-    ///
-    /// let x: Result<i32, &str> = Result::new_err("Some error message");
-    /// assert_eq!(x.is_err(), true);
-    /// ```
-    #[must_use = "if you intended to assert that this is err, consider `.unwrap_err()` instead"]
-    #[inline]
-    pub const fn is_err(&self) -> bool {
-        !self.is_ok()
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // Adapter for each variant
-    /////////////////////////////////////////////////////////////////////////
-
-    /// Converts from `Result<T, E>` to [`Option<T>`].
-    ///
-    /// Converts `self` into an [`Option<T>`], consuming `self`,
-    /// and discarding the error, if any.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(2);
-    /// assert_eq!(x.ok(), Some(2));
-    ///
-    /// let x: Result<u32, &str> = Result::new_err("Nothing here");
-    /// assert_eq!(x.ok(), None);
-    /// ```
-    #[inline]
-    pub fn ok(self) -> Option<T> {
-        match self {
-            Ok(x) => Some(x),
-            Err(_) => None,
-        }
-    }
-
-    /// Converts from `Result<T, E>` to [`Option<E>`].
-    ///
-    /// Converts `self` into an [`Option<E>`], consuming `self`,
-    /// and discarding the success value, if any.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(2);
-    /// assert_eq!(x.err(), None);
-    ///
-    /// let x: Result<u32, &str> = Result::new_err("Nothing here");
-    /// assert_eq!(x.err(), Some("Nothing here"));
-    /// ```
-    #[inline]
-    pub fn err(self) -> Option<E> {
-        match self {
-            Ok(_) => None,
-            Err(x) => Some(x.error),
-        }
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // Adapter for working with references
-    /////////////////////////////////////////////////////////////////////////
-
-    // TODO: how to do this? I think the returned result should have a `&T` or a `&TracedError<E>`,
-    // but idk how to make that happen.
-    /*
-    /// Converts from `&Result<T, E>` to `Result<&T, &E>`.
-    ///
-    /// Produces a new `Result`, containing a reference
-    /// into the original, leaving the original in place.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// let x: Result<u32, &str> = Ok(2);
-    /// assert_eq!(x.as_ref(), Ok(&2));
-    ///
-    /// let x: Result<u32, &str> = Result::new_err("Error");
-    /// assert_eq!(x.as_ref(), Err(&"Error"));
-    /// ```
-    #[inline]
-    pub const fn as_ref(&self) -> Result<&T, &E> {
-        match *self {
-            Ok(ref x) => Ok(x),
-            Err(ref x) => Err(x),
-        }
-    }
-    */
-
-    // TODO: how to do this? I think the returned result should have a `&mut T` or a
-    // `&mut TracedError<E>`, but idk how to make that happen.
-    /*
-    /// Converts from `&mut Result<T, E>` to `Result<&mut T, &mut E>`.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// fn mutate(r: &mut Result<i32, i32>) {
-    ///     match r.as_mut() {
-    ///         Ok(v) => *v = 42,
-    ///         Err(e) => *e = 0,
-    ///     }
-    /// }
-    ///
-    /// let mut x: Result<i32, i32> = Ok(2);
-    /// mutate(&mut x);
-    /// assert_eq!(x.unwrap(), 42);
-    ///
-    /// let mut x: Result<i32, i32> = Result::new_err(13);
-    /// mutate(&mut x);
-    /// assert_eq!(x.unwrap_err(), 0);
-    /// ```
-    #[inline]
-    pub fn as_mut(&mut self) -> Result<&mut T, &mut E> {
-        match *self {
-            Ok(ref mut x) => Ok(x),
-            Err(ref mut x) => Err(x),
-        }
-    }
-    */
-
-    /////////////////////////////////////////////////////////////////////////
-    // Transforming contained values
-    /////////////////////////////////////////////////////////////////////////
-
-    // TODO: map
-    // TODO: map_or
-    // TODO: map_or_else
-
-    /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
-    /// contained [`Err`] value, leaving an [`Ok`] value untouched.
-    ///
-    /// This function can be used to pass through a successful result while handling
-    /// an error.
-    ///
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// fn stringify(x: i32) -> String { format!("error code: {}", x) }
-    ///
-    /// let x: Result<i32, i32> = propagate::Ok(2);
-    /// assert_eq!(x.map_err(stringify), propagate::Ok(2));
-    ///
-    /// let x: Result<i32, i32> = Result::new_err(13);
-    /// let y: Result<i32, String> = x.map_err(stringify);
-    /// assert_eq!(y.err().unwrap(), "error code: 13".to_string());
-    /// ```
-    #[inline]
-    pub fn map_err<F, O: FnOnce(E) -> F>(self, op: O) -> Result<T, F> {
-        // XXX: should this push_caller? I think probably not, as users will just use
-        // `?` with whatever comes out of this.
-        match self {
-            Ok(t) => Ok(t),
-            Err(e) => Err(TracedError {
-                error: op(e.error),
-                stack: e.stack,
-            }),
-        }
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // Boolean operations on the values, eager and lazy
-    /////////////////////////////////////////////////////////////////////////
-
-    /// Returns the contained [`Ok`] value or a provided default.
-    ///
-    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing
-    /// the result of a function call, it is recommended to use [`unwrap_or_else`],
-    /// which is lazily evaluated.
-    ///
-    /// [`unwrap_or_else`]: Result::unwrap_or_else
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let default = 2;
-    /// let x: Result<u32, &str> = propagate::Ok(9);
-    /// assert_eq!(x.unwrap_or(default), 9);
-    ///
-    /// let x: Result<u32, &str> = Result::new_err("error");
-    /// assert_eq!(x.unwrap_or(default), default);
-    /// ```
-    #[inline]
-    pub fn unwrap_or(self, default: T) -> T {
-        match self {
-            Ok(t) => t,
-            Err(_) => default,
-        }
-    }
-
-    /// Returns the contained [`Ok`] value or computes it from a closure.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// fn count(x: &str) -> usize { x.len() }
-    ///
-    /// assert_eq!(Ok(2).unwrap_or_else(count), 2);
-    /// assert_eq!(Err("foo").unwrap_or_else(count), 3);
-    /// ```
-    #[inline]
-    pub fn unwrap_or_else<F: FnOnce(E) -> T>(self, op: F) -> T {
-        match self {
-            Ok(t) => t,
-            Err(e) => op(e.error),
-        }
-    }
-}
-
-impl<T, E: fmt::Debug> Result<T, E> {
-    /// Returns the contained [`Ok`] value, consuming the `self` value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is an [`Err`], with a panic message including the
-    /// passed message, and the content of the [`Err`].
-    ///
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```should_panic
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = Result::new_err("emergency failure");
-    /// x.expect("Testing expect"); // panics with `Testing expect: emergency failure`
-    /// ```
-    #[inline]
-    #[track_caller]
-    pub fn expect(self, msg: &str) -> T {
-        match self {
-            Ok(t) => t,
-            Err(e) => unwrap_failed(msg, &e),
-        }
-    }
-
-    /// Returns the contained [`Ok`] value, consuming the `self` value.
-    ///
-    /// Because this function may panic, its use is generally discouraged.
-    /// Instead, prefer to use pattern matching and handle the [`Err`]
-    /// case explicitly, or call [`unwrap_or`], [`unwrap_or_else`], or
-    /// [`unwrap_or_default`].
-    ///
-    /// [`unwrap_or`]: Result::unwrap_or
-    /// [`unwrap_or_else`]: Result::unwrap_or_else
-    /// [`unwrap_or_default`]: Result::unwrap_or_default
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is an [`Err`], with a panic message provided by the
-    /// [`Err`]'s value.
-    ///
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(2);
-    /// assert_eq!(x.unwrap(), 2);
-    /// ```
-    ///
-    /// ```should_panic
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = Result::new_err("emergency failure");
-    /// x.unwrap(); // panics with `emergency failure`
-    /// ```
-    #[inline]
-    #[track_caller]
-    pub fn unwrap(self) -> T {
-        match self {
-            Ok(t) => t,
-            Err(e) => unwrap_failed("called `Result::unwrap()` on an `Err` value", &e),
-        }
-    }
-}
-
-impl<T: fmt::Debug, E> Result<T, E> {
-    /// Returns the contained [`Err`] value, consuming the `self` value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is an [`Ok`], with a panic message including the
-    /// passed message, and the content of the [`Ok`].
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```should_panic
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(10);
-    /// x.expect_err("Testing expect_err"); // panics with `Testing expect_err: 10`
-    /// ```
-    #[inline]
-    #[track_caller]
-    pub fn expect_err(self, msg: &str) -> E {
-        match self {
-            Ok(t) => unwrap_failed(msg, &t),
-            Err(e) => e.error,
-        }
-    }
-
-    /// Returns the contained [`Err`] value, consuming the `self` value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is an [`Ok`], with a custom panic message provided
-    /// by the [`Ok`]'s value.
-    ///
-    /// # Examples
-    ///
-    /// ```should_panic
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = propagate::Ok(2);
-    /// x.unwrap_err(); // panics with `2`
-    /// ```
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let x: Result<u32, &str> = Result::new_err("emergency failure");
-    /// assert_eq!(x.unwrap_err(), "emergency failure");
-    /// ```
-    #[inline]
-    #[track_caller]
-    pub fn unwrap_err(self) -> E {
-        match self {
-            Ok(t) => unwrap_failed("called `Result::unwrap_err()` on an `Ok` value", &t),
-            Err(e) => e.error,
-        }
-    }
-}
-
-impl<T: Default, E> Result<T, E> {
-    /// Returns the contained [`Ok`] value or a default
-    ///
-    /// Consumes the `self` argument then, if [`Ok`], returns the contained
-    /// value, otherwise if [`Err`], returns the default value for that
-    /// type.
-    ///
-    /// # Examples
-    ///
-    /// Converts a string to an integer, turning poorly-formed strings
-    /// into 0 (the default value for integers). [`parse`] converts
-    /// a string to any other type that implements [`FromStr`], returning an
-    /// [`Err`] on error.
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// let good_year_from_input = "1909";
-    /// let bad_year_from_input = "190blarg";
-    /// let good_year = good_year_from_input.parse().unwrap_or_default();
-    /// let bad_year = bad_year_from_input.parse().unwrap_or_default();
-    ///
-    /// assert_eq!(1909, good_year);
-    /// assert_eq!(0, bad_year);
-    /// ```
-    ///
-    /// [`parse`]: str::parse
-    /// [`FromStr`]: crate::str::FromStr
-    #[inline]
-    pub fn unwrap_or_default(self) -> T {
-        match self {
-            Ok(x) => x,
-            Err(_) => Default::default(),
-        }
-    }
-}
-
-impl<T, E> Result<Option<T>, E> {
-    /// Transposes a `Result` of an `Option` into an `Option` of a `Result`.
-    ///
-    /// `Ok(None)` will be mapped to `None`.
-    /// `Ok(Some(_))` and `Err(_)` will be mapped to `Some(Ok(_))` and `Some(Err(_))`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use propagate::result::Result;
-    /// #[derive(Debug, Eq, PartialEq)]
-    /// struct SomeErr;
-    ///
-    /// let x: Result<Option<i32>, SomeErr> = propagate::Ok(Some(5));
-    /// let y: Option<Result<i32, SomeErr>> = Some(propagate::Ok(5));
-    /// assert_eq!(x.transpose(), y);
-    /// ```
-    #[inline]
-    pub fn transpose(self) -> Option<Result<T, E>> {
-        match self {
-            Ok(Some(x)) => Some(Ok(x)),
-            Ok(None) => None,
-            Err(e) => Some(Err(e)),
-        }
-    }
-}
-
-// This is a separate function to reduce the code size of the methods
-#[inline(never)]
-#[cold]
-#[track_caller]
-fn unwrap_failed(msg: &str, error: &dyn fmt::Debug) -> ! {
-    panic!("{}: {:?}", msg, error)
 }
 
 /*  _            _
@@ -890,20 +386,12 @@ mod test {
 
     #[test]
     fn new_err_coerce() {
-        fn inner() -> Result<u32, String> {
-            let x: Result<u32, String> = Result::new_err("string slice");
+        fn func() -> Result<u32, String> {
+            let x: Result<u32, String> = err("string slice");
             x
         }
-        assert_eq!(inner().err().unwrap(), String::from("string slice"));
-    }
-
-    #[test]
-    fn can_convert_to_std_result() {
-        let x: Result<u32, &str> = Ok(2);
-        assert_eq!(x.to_std(), std::result::Result::Ok(2));
-
-        let x: Result<u32, &str> = Result::new_err("Nothing here");
-        assert_eq!(x.to_std(), std::result::Result::Err("Nothing here"));
+        let (result, _stack) = func().unpack();
+        assert_eq!(result, Err(String::from("string slice")));
     }
 
     /*   ____ _           _       _
@@ -920,7 +408,7 @@ mod test {
         if fail {
             let _ = fs::File::open("/nonexistent/file")?;
         }
-        Ok(())
+        ok(())
     }
 
     #[test]
@@ -928,7 +416,7 @@ mod test {
         let mut fix = Fixture::default();
 
         let result = maybe_io_error(&mut fix, false);
-        assert!(matches!(result, Ok(())));
+        assert!(matches!(result.0, Ok(())));
     }
 
     #[test]
@@ -945,7 +433,7 @@ mod test {
 
         let mut bottom = || -> Result<(), io::Error> {
             fix.tag_location("bottom", CodeLocation::here().down_by(1));
-            Ok(maybe_io_error(&mut fix, true)?)
+            ok(maybe_io_error(&mut fix, true)?)
         };
 
         let result = bottom();
@@ -990,7 +478,7 @@ mod test {
         let mut bottom = || -> Result<(), MyError> {
             fix.tag_location("bottom", CodeLocation::here().down_by(1));
             maybe_io_error(&mut fix, true)?;
-            Ok(())
+            ok(())
         };
 
         let result = bottom();
@@ -1003,7 +491,7 @@ mod test {
 
         let mut bottom = || -> Result<(), MyError> {
             fix.tag_location("bottom", CodeLocation::here().down_by(1));
-            Ok(maybe_io_error(&mut fix, true)?)
+            ok(maybe_io_error(&mut fix, true)?)
         };
 
         let result = bottom();
@@ -1016,7 +504,7 @@ mod test {
 
         let mut bottom = || -> Result<(), MyError> {
             fix.tag_location("bottom", CodeLocation::here().down_by(1));
-            Result::new_err("oops".to_string())
+            err("oops".to_string())
         };
 
         let result = bottom();
@@ -1030,7 +518,7 @@ mod test {
         let mut bottom = || -> Result<(), MyError> {
             let my_error = MyError::Other("oops".to_string());
             fix.tag_location("bottom", CodeLocation::here().down_by(1));
-            Result::new_err(my_error)
+            err(my_error)
         };
 
         let result = bottom();

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,6 @@
 //! Helper class for testing.
 
-use crate::prelude::*;
-use crate::{CodeLocation, CodeLocationStack, TracedError};
+use crate::{CodeLocation, CodeLocationStack, Result, TracedError};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -16,7 +15,7 @@ mod tests {
         fix.tag_location("tag", CodeLocation::here());
         assert_eq!(
             *fix.get_location("tag"),
-            CodeLocation::new("src/test.rs", 16)
+            CodeLocation::new("src/test.rs", 15)
         );
     }
 }
@@ -53,7 +52,8 @@ impl Fixture {
         result: Result<T, E>,
         tags: &[&'static str],
     ) {
-        let err_stack = result.err_stack().unwrap();
-        self.assert_error_has_stack(&err_stack, tags);
+        let (result, stack) = result.unpack();
+        assert!(result.is_err());
+        self.assert_stack_matches_tags(&stack.unwrap(), tags);
     }
 }


### PR DESCRIPTION
Previously, `propagate::Result` was mostly a copy of `std::result::Result`, with a different `Err` type and modified `FromResidual` implementations.

Because of this, users would have to to use `propagate::Result::{Ok, Err}` to construct results (unless they used
`try` blocks).

This changes `propagate::Result<T, E, S>` to be a minimal wrapper around a `std::result::Result<T, TracedError<E, S>>`. If users want to get to the wrapped result, they can call `.unpack()`, which will also return the traced stack if there is one.

With this change, users no longer need to (nor have the ability to) shadow the standard library's `Ok` and `Err`.
Now, there should be much less confusion about what a `propagate::Result` really is. It no longer pretends to be the same
thing as a `std::result::Result`.